### PR TITLE
optimize: update codeql and ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,4 +21,15 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Test with Maven
-        run: mvn test -B --file pom.xml
+        run: |
+          directories=("at-sample" "saga-sample" "tcc-sample" "xa-sample")
+          for dir in "${directories[@]}"; do
+            for subdir in "$dir"/*; do
+              if [ -d "$subdir" ]; then
+                echo "Entering directory $subdir"
+                cd "$subdir"
+                mvn -B test
+                cd - > /dev/null
+              fi
+            done
+          done

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,6 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,10 +50,19 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Build
+      run: |
+        directories=("at-sample" "saga-sample" "tcc-sample" "xa-sample")
+        for dir in "${directories[@]}"; do
+          for subdir in "$dir"/*; do
+            if [ -d "$subdir" ]; then
+              echo "Entering directory $subdir"
+              cd "$subdir"
+              mvn -B package
+              cd - > /dev/null
+            fi
+          done
+        done
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Upgrade codeql related github action versions. And since we change the sample structure (without a root pom.xml), there is a CI error. To fix it, I change the "Autobuild" step of codeql and "Test with maven" step of ci.
<img width="895" alt="image" src="https://github.com/apache/incubator-seata-samples/assets/32592585/638c68a7-6bec-4dd7-b281-a3b7c04994e4">




