### PR TITLE
bugfix: bump rpc-sofa-boot-starter version to latest

### DIFF
--- a/tcc-sample/springboot-sofarpc-seata-tcc/pom.xml
+++ b/tcc-sample/springboot-sofarpc-seata-tcc/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.alipay.sofa</groupId>
       <artifactId>rpc-sofa-boot-starter</artifactId>
-      <version>5.12.0</version>
+      <version>6.0.4</version>
       <exclusions>
         <exclusion>
           <artifactId>spring-beans</artifactId>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

rpc-sofa-boot-starter version 5.12.0 does not exist, change it to latest version.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #674 


